### PR TITLE
Add break to prevent multiple collisions at same time

### DIFF
--- a/src/main/java/mario/model/Player.java
+++ b/src/main/java/mario/model/Player.java
@@ -225,6 +225,7 @@ public final class Player extends AnimatedSpriteObject implements ICollidableWit
                 if (tile.getTile() instanceof LavaTile) {
                     removeOneHealthPoint();
                     resetPlayer();
+                    break;
                 }
 
                 switch (tile.getCollisionSide()) {


### PR DESCRIPTION
Fixed bug when player collisions with Lava, it loses 2 health points instead of one.
Added break inside tileCollisionOccurred to break out the loop when collision happens.